### PR TITLE
fix: request type annotation

### DIFF
--- a/lemon/trading/orders.py
+++ b/lemon/trading/orders.py
@@ -13,7 +13,6 @@ from lemon.trading.model import (
     OrderType,
     Venue,
 )
-from lemon.types import Days
 
 
 class Orders:
@@ -53,7 +52,7 @@ class Orders:
         isin: str,
         side: OrderSide,
         quantity: int,
-        expires_at: Union[date, Days, None] = None,
+        expires_at: Union[date, str, None] = None,
         stop_price: Optional[int] = None,
         limit_price: Optional[int] = None,
         venue: Optional[Venue] = None,

--- a/tests/trading/test_orders.py
+++ b/tests/trading/test_orders.py
@@ -437,7 +437,7 @@ class TestCreateOrderApi(CommonTradingApiTests):
     def make_api_call(self, client: Api):
         return client.trading.orders.create(
             isin="DE0008232125",
-            expires_at=7,
+            expires_at="7d",
             side="buy",
             quantity=1000,
             venue="xmun",


### PR DESCRIPTION
Orders `expires_at` allows a datetime or a time interval e.g. `(P)2d` as an input but not an integer, which `Days` was an alias for.

Days is also used in the market data API for the `to` params and manually converted to `p{x}d`. We could also adjust it there 