### PR TITLE
feat(trading): add iterator based on iterable response type

### DIFF
--- a/lemon/market_data/instruments.py
+++ b/lemon/market_data/instruments.py
@@ -10,16 +10,16 @@ class Instruments:
         self._client = client
 
     def get(
-        self,
-        isin: Optional[List[str]] = None,
-        search: Optional[str] = None,
-        type: Optional[List[InstrumentType]] = None,
-        mic: Optional[List[str]] = None,
-        currency: Optional[List[str]] = None,
-        tradable: Optional[bool] = None,
-        sorting: Optional[Sorting] = None,
-        limit: Optional[int] = None,
-        page: Optional[int] = None,
+            self,
+            isin: Optional[List[str]] = None,
+            search: Optional[str] = None,
+            type: Optional[List[InstrumentType]] = None,
+            mic: Optional[List[str]] = None,
+            currency: Optional[List[str]] = None,
+            tradable: Optional[bool] = None,
+            sorting: Optional[Sorting] = None,
+            limit: Optional[int] = None,
+            page: Optional[int] = None,
     ) -> GetInstrumentsResponse:
         resp = self._client.get(
             "instruments",
@@ -35,4 +35,4 @@ class Instruments:
                 "page": page,
             },
         )
-        return GetInstrumentsResponse._from_data(resp.json())
+        return GetInstrumentsResponse._from_data(resp.json(), self._client)

--- a/lemon/market_data/instruments.py
+++ b/lemon/market_data/instruments.py
@@ -10,16 +10,16 @@ class Instruments:
         self._client = client
 
     def get(
-            self,
-            isin: Optional[List[str]] = None,
-            search: Optional[str] = None,
-            type: Optional[List[InstrumentType]] = None,
-            mic: Optional[List[str]] = None,
-            currency: Optional[List[str]] = None,
-            tradable: Optional[bool] = None,
-            sorting: Optional[Sorting] = None,
-            limit: Optional[int] = None,
-            page: Optional[int] = None,
+        self,
+        isin: Optional[List[str]] = None,
+        search: Optional[str] = None,
+        type: Optional[List[InstrumentType]] = None,
+        mic: Optional[List[str]] = None,
+        currency: Optional[List[str]] = None,
+        tradable: Optional[bool] = None,
+        sorting: Optional[Sorting] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
     ) -> GetInstrumentsResponse:
         resp = self._client.get(
             "instruments",

--- a/lemon/market_data/model/instrument.py
+++ b/lemon/market_data/model/instrument.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from typing_extensions import Literal
 
-from lemon.types import BaseModel
+from lemon.types import BaseModel, IterableResponseBase
 
 
 @dataclass
@@ -32,7 +32,7 @@ class Instrument(BaseModel):
 
 
 @dataclass
-class GetInstrumentsResponse(BaseModel):
+class GetInstrumentsResponse(IterableResponseBase):
     time: datetime
     results: List[Instrument]
     total: int

--- a/lemon/market_data/model/ohlc.py
+++ b/lemon/market_data/model/ohlc.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Union
 
-from lemon.types import BaseModel
+from lemon.types import BaseModel, IterableResponseBase
 
 
 @dataclass
@@ -37,7 +37,7 @@ class OhlcData(BaseModel):
 
 
 @dataclass
-class GetOhlcResponse(BaseModel):
+class GetOhlcResponse(IterableResponseBase):
     time: datetime
     results: List[OhlcData]
     total: int
@@ -49,6 +49,7 @@ class GetOhlcResponse(BaseModel):
         data: Dict[str, Any],
         t_type: Callable[[Any], Union[int, float]],
         k_type: Callable[[Any], Union[datetime, int]],
+        client: "Client",
     ) -> "GetOhlcResponse":
         return GetOhlcResponse(
             time=datetime.fromisoformat(data["time"]),
@@ -58,4 +59,6 @@ class GetOhlcResponse(BaseModel):
             total=int(data["total"]),
             page=int(data["page"]),
             pages=int(data["pages"]),
+            _client=client,
+            next=data["next"],
         )

--- a/lemon/market_data/model/quote.py
+++ b/lemon/market_data/model/quote.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Union
 
-from lemon.types import BaseModel
+from lemon.types import BaseModel, IterableResponseBase
 
 
 @dataclass
@@ -33,7 +33,7 @@ class Quote(BaseModel):
 
 
 @dataclass
-class GetQuotesResponse(BaseModel):
+class GetQuotesResponse(IterableResponseBase):
     time: datetime
     results: List[Quote]
     total: int
@@ -45,6 +45,7 @@ class GetQuotesResponse(BaseModel):
         data: Dict[str, Any],
         t_type: Callable[[Any], Union[int, float]],
         k_type: Callable[[Any], Union[datetime, int]],
+        client: "Client",
     ) -> "GetQuotesResponse":
         return GetQuotesResponse(
             time=datetime.fromisoformat(data["time"]),
@@ -54,4 +55,6 @@ class GetQuotesResponse(BaseModel):
             total=int(data["total"]),
             page=int(data["page"]),
             pages=int(data["pages"]),
+            _client=client,
+            next=data["next"],
         )

--- a/lemon/market_data/model/trade.py
+++ b/lemon/market_data/model/trade.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Union
 
-from lemon.types import BaseModel
+from lemon.types import BaseModel, IterableResponseBase
 
 
 @dataclass
@@ -31,7 +31,7 @@ class Trade(BaseModel):
 
 
 @dataclass
-class GetTradesResponse(BaseModel):
+class GetTradesResponse(IterableResponseBase):
     time: datetime
     results: List[Trade]
     total: int
@@ -43,6 +43,7 @@ class GetTradesResponse(BaseModel):
         data: Dict[str, Any],
         t_type: Callable[[Any], Union[int, float]],
         k_type: Callable[[Any], Union[datetime, int]],
+        client: "Client",
     ) -> "GetTradesResponse":
         return GetTradesResponse(
             time=datetime.fromisoformat(data["time"]),
@@ -52,4 +53,6 @@ class GetTradesResponse(BaseModel):
             total=int(data["total"]),
             page=int(data["page"]),
             pages=int(data["pages"]),
+            _client=client,
+            next=data["next"],
         )

--- a/lemon/market_data/ohlc.py
+++ b/lemon/market_data/ohlc.py
@@ -47,4 +47,5 @@ class Ohlc:
             data=resp.json(),
             t_type=float if decimals else int,
             k_type=int if epoch else datetime.fromisoformat,  # type: ignore
+            client=self._client,
         )

--- a/lemon/market_data/quotes.py
+++ b/lemon/market_data/quotes.py
@@ -36,5 +36,5 @@ class Quotes:
             data=resp.json(),
             t_type=float if decimals else int,
             k_type=int if epoch else datetime.fromisoformat,  # type: ignore
-            client=self._client
+            client=self._client,
         )

--- a/lemon/market_data/quotes.py
+++ b/lemon/market_data/quotes.py
@@ -36,4 +36,5 @@ class Quotes:
             data=resp.json(),
             t_type=float if decimals else int,
             k_type=int if epoch else datetime.fromisoformat,  # type: ignore
+            client=self._client
         )

--- a/lemon/market_data/trades.py
+++ b/lemon/market_data/trades.py
@@ -36,4 +36,5 @@ class Trades:
             data=resp.json(),
             t_type=float if decimals else int,
             k_type=int if epoch else datetime.fromisoformat,  # type: ignore
+            client=self._client,
         )

--- a/lemon/trading/account.py
+++ b/lemon/trading/account.py
@@ -54,7 +54,7 @@ class Account:
                 "page": page,
             },
         )
-        return GetWithdrawalsResponse._from_data(resp.json())
+        return GetWithdrawalsResponse._from_data(resp.json(), client=self._client)
 
     def withdraw(
         self,
@@ -108,7 +108,7 @@ class Account:
                 "page": page,
             },
         )
-        return GetDocumentsResponse._from_data(resp.json())
+        return GetDocumentsResponse._from_data(resp.json(), client=self._client)
 
     def get_document(
         self, document_id: str, no_redirect: Optional[bool] = None

--- a/lemon/trading/account.py
+++ b/lemon/trading/account.py
@@ -92,7 +92,7 @@ class Account:
                 "page": page,
             },
         )
-        return GetBankStatementsResponse._from_data(resp.json())
+        return GetBankStatementsResponse._from_data(resp.json(), client=self._client)
 
     def get_documents(
         self,

--- a/lemon/trading/model/account.py
+++ b/lemon/trading/model/account.py
@@ -62,7 +62,7 @@ class Withdrawal(BaseModel):
 
 
 @dataclass
-class GetWithdrawalsResponse(BaseModel):
+class GetWithdrawalsResponse(IterableResponseBase):
     time: datetime
     mode: Environment
     results: List[Withdrawal]
@@ -125,7 +125,7 @@ class Document(BaseModel):
 
 
 @dataclass
-class GetDocumentsResponse(BaseModel):
+class GetDocumentsResponse(IterableResponseBase):
     time: datetime
     mode: Environment
     results: List[Document]

--- a/lemon/trading/model/account.py
+++ b/lemon/trading/model/account.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from typing_extensions import Literal
 
-from lemon.types import BaseModel, Environment
+from lemon.types import BaseModel, Environment, IterableResponseBase
 
 Plan = Literal["go", "investor", "trader"]
 
@@ -104,7 +104,7 @@ class BankStatement(BaseModel):
 
 
 @dataclass
-class GetBankStatementsResponse(BaseModel):
+class GetBankStatementsResponse(IterableResponseBase):
     time: datetime
     mode: Environment
     results: List[BankStatement]

--- a/lemon/trading/model/order.py
+++ b/lemon/trading/model/order.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from typing_extensions import Literal
 
-from lemon.types import BaseModel, Environment
+from lemon.types import BaseModel, Environment, IterableResponseBase
 
 OrderSide = Literal["sell", "buy"]
 OrderStatus = Literal[
@@ -78,7 +78,7 @@ class Order(BaseModel):
 
 
 @dataclass
-class GetOrdersResponse(BaseModel):
+class GetOrdersResponse(IterableResponseBase):
     time: datetime
     mode: Environment
     results: List[Order]

--- a/lemon/trading/model/position.py
+++ b/lemon/trading/model/position.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from typing_extensions import Literal
 
-from lemon.types import BaseModel, Environment
+from lemon.types import BaseModel, Environment, IterableResponseBase
 
 StatementType = Literal["order_buy", "order_sell", "split", "import", "snx"]
 
@@ -20,7 +20,7 @@ class Position(BaseModel):
 
 
 @dataclass
-class GetPositionsResponse(BaseModel):
+class GetPositionsResponse(IterableResponseBase):
     time: datetime
     mode: Environment
     results: List[Position]
@@ -43,7 +43,7 @@ class Statement(BaseModel):
 
 
 @dataclass
-class GetStatementsResponse(BaseModel):
+class GetStatementsResponse(IterableResponseBase):
     time: datetime
     mode: Environment
     results: List[Statement]
@@ -67,7 +67,7 @@ class Performance(BaseModel):
 
 
 @dataclass
-class GetPerformanceResponse(BaseModel):
+class GetPerformanceResponse(IterableResponseBase):
     time: datetime
     mode: Environment
     results: List[Performance]

--- a/lemon/trading/orders.py
+++ b/lemon/trading/orders.py
@@ -47,7 +47,7 @@ class Orders:
                 "page": page,
             },
         )
-        return GetOrdersResponse._from_data(resp.json())
+        return GetOrdersResponse._from_data(resp.json(), client=self._client)
 
     def create(
         self,

--- a/lemon/trading/positions.py
+++ b/lemon/trading/positions.py
@@ -29,7 +29,7 @@ class Positions:
                 "page": page,
             },
         )
-        return GetPositionsResponse._from_data(resp.json())
+        return GetPositionsResponse._from_data(resp.json(), client=self._client)
 
     def get_statements(
         self,
@@ -53,7 +53,7 @@ class Positions:
                 "page": page,
             },
         )
-        return GetStatementsResponse._from_data(resp.json())
+        return GetStatementsResponse._from_data(resp.json(), client=self._client)
 
     def get_performance(
         self,
@@ -75,4 +75,4 @@ class Positions:
                 "page": page,
             },
         )
-        return GetPerformanceResponse._from_data(resp.json())
+        return GetPerformanceResponse._from_data(resp.json(), client=self._client)

--- a/lemon/types.py
+++ b/lemon/types.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, time, timezone
 from typing import (
     Any,
@@ -11,7 +11,7 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    Union,
+    Union, Optional,
 )
 
 from typing_extensions import Literal
@@ -127,8 +127,8 @@ class BaseModel(metaclass=BaseModelMeta):
 
 @dataclass
 class IterableResponseBase(BaseModel):
-    next: str
-    _client: "Client"
+    next: Optional[str]
+    _client: Optional["Client"]
 
     @classmethod
     def _from_data(

--- a/lemon/types.py
+++ b/lemon/types.py
@@ -1,18 +1,7 @@
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import date, datetime, time, timezone
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Iterator,
-    List,
-    Tuple,
-    Type,
-    TypeVar,
-    Union, Optional,
-)
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Type, TypeVar, Union
 
 from typing_extensions import Literal
 
@@ -86,7 +75,7 @@ def _make_parser(type_: Type[Any]) -> Callable[[Any], Any]:
 
 class BaseModelMeta(type):
     def __new__(
-            cls, name: str, bases: Tuple[Any], dct: Dict[str, Any]
+        cls, name: str, bases: Tuple[Any], dct: Dict[str, Any]
     ) -> "BaseModelMeta":
         if "__annotations__" not in dct:
             return super().__new__(cls, name, bases, dct)
@@ -132,7 +121,7 @@ class IterableResponseBase(BaseModel):
 
     @classmethod
     def _from_data(
-            cls: Type[TBaseModel], data: Dict[str, Any], client: "Client"
+        cls: Type[TBaseModel], data: Dict[str, Any], client: "Client"
     ) -> TBaseModel:
         kwargs = {}
 

--- a/lemon/types.py
+++ b/lemon/types.py
@@ -125,13 +125,9 @@ class BaseModel(metaclass=BaseModelMeta):
         return cls(**kwargs)
 
 
-T = TypeVar("T", bound="List")
-
-
 @dataclass
-class IterableResponseBase(BaseModel, Generic[T]):
+class IterableResponseBase(BaseModel):
     next: str
-    results: T
     _client: "Client"
 
     @classmethod

--- a/lemon/types.py
+++ b/lemon/types.py
@@ -86,7 +86,7 @@ def _make_parser(type_: Type[Any]) -> Callable[[Any], Any]:
 
 class BaseModelMeta(type):
     def __new__(
-        cls, name: str, bases: Tuple[Any], dct: Dict[str, Any]
+            cls, name: str, bases: Tuple[Any], dct: Dict[str, Any]
     ) -> "BaseModelMeta":
         if "__annotations__" not in dct:
             return super().__new__(cls, name, bases, dct)
@@ -132,7 +132,7 @@ class IterableResponseBase(BaseModel):
 
     @classmethod
     def _from_data(
-        cls: Type[TBaseModel], data: Dict[str, Any], client: "Client"
+            cls: Type[TBaseModel], data: Dict[str, Any], client: "Client"
     ) -> TBaseModel:
         kwargs = {}
 
@@ -144,9 +144,13 @@ class IterableResponseBase(BaseModel):
 
     def auto_iter(self) -> Iterator:
         data = self
-        while data.next is not None:
+        while True:
             for el in data.results:
                 yield el
+
+            if not data.next:
+                break
+
             data = self._from_data(
                 self._client.get(data.next).json(), client=self._client
             )

--- a/lemon/types.py
+++ b/lemon/types.py
@@ -75,7 +75,7 @@ def _make_parser(type_: Type[Any]) -> Callable[[Any], Any]:
 
 class BaseModelMeta(type):
     def __new__(
-        cls, name: str, bases: Tuple[Any], dct: Dict[str, Any]
+            cls, name: str, bases: Tuple[Any], dct: Dict[str, Any]
     ) -> "BaseModelMeta":
         if "__annotations__" not in dct:
             return super().__new__(cls, name, bases, dct)
@@ -102,7 +102,7 @@ class BaseModel(metaclass=BaseModelMeta):
         return json.dumps(asdict(self), cls=JSONEncoder)
 
     @classmethod
-    def _from_data(cls: Type[TBaseModel], data: Dict[str, Any]) -> TBaseModel:
+    def _from_data(cls: Type[TBaseModel], data: Dict[str, Any], **kwargs) -> TBaseModel:
         kwargs = {}
 
         for key, parser in cls._parsers.items():  # type: ignore # pylint: disable=E1101
@@ -110,3 +110,19 @@ class BaseModel(metaclass=BaseModelMeta):
             kwargs[key] = parser(val) if val is not None else None
 
         return cls(**kwargs)
+
+
+class IterableResponseBase(BaseModel):
+    next: str
+
+    __client: "Client"
+
+    @classmethod
+    def _from_data(cls: Type[TBaseModel], data: Dict[str, Any], client: "Client") -> TBaseModel:
+        kwargs = {}
+
+        for key, parser in cls._parsers.items():  # type: ignore # pylint: disable=E1101
+            val = data.get(key)
+            kwargs[key] = parser(val) if val is not None else None
+
+        return cls(**kwargs, __client=client)

--- a/tests/market_data/model/test_instrument.py
+++ b/tests/market_data/model/test_instrument.py
@@ -28,7 +28,7 @@ RESPONSE = GetInstrumentsResponse(
     page=2,
     pages=263,
     next=None,
-    _client=None
+    _client=None,
 )
 
 DICT_RESPONSE = {
@@ -56,6 +56,8 @@ DICT_RESPONSE = {
     "total": 26283,
     "page": 2,
     "pages": 263,
+    "_client": None,
+    "next": None,
 }
 
 

--- a/tests/market_data/model/test_instrument.py
+++ b/tests/market_data/model/test_instrument.py
@@ -27,6 +27,8 @@ RESPONSE = GetInstrumentsResponse(
     total=26283,
     page=2,
     pages=263,
+    next=None,
+    _client=None
 )
 
 DICT_RESPONSE = {

--- a/tests/market_data/model/test_ohlc.py
+++ b/tests/market_data/model/test_ohlc.py
@@ -20,6 +20,8 @@ RESPONSE = GetOhlcResponse(
     total=1,
     page=1,
     pages=1,
+    _client=None,
+    next=None,
 )
 
 DICT_RESPONSE = {
@@ -40,6 +42,8 @@ DICT_RESPONSE = {
     "total": 1,
     "page": 1,
     "pages": 1,
+    "_client": None,
+    "next": None,
 }
 
 

--- a/tests/market_data/model/test_quote.py
+++ b/tests/market_data/model/test_quote.py
@@ -18,6 +18,8 @@ RESPONSE = GetQuotesResponse(
     total=1,
     page=1,
     pages=1,
+    _client=None,
+    next=None
 )
 
 DICT_RESPONSE = {
@@ -36,6 +38,8 @@ DICT_RESPONSE = {
     "total": 1,
     "page": 1,
     "pages": 1,
+    "_client": None,
+    "next": None
 }
 
 

--- a/tests/market_data/model/test_quote.py
+++ b/tests/market_data/model/test_quote.py
@@ -19,7 +19,7 @@ RESPONSE = GetQuotesResponse(
     page=1,
     pages=1,
     _client=None,
-    next=None
+    next=None,
 )
 
 DICT_RESPONSE = {
@@ -39,7 +39,7 @@ DICT_RESPONSE = {
     "page": 1,
     "pages": 1,
     "_client": None,
-    "next": None
+    "next": None,
 }
 
 

--- a/tests/market_data/model/test_trade.py
+++ b/tests/market_data/model/test_trade.py
@@ -17,6 +17,8 @@ RESPONSE = GetTradesResponse(
     total=1,
     page=1,
     pages=1,
+    next=None,
+    _client=None,
 )
 
 DICT_RESPONSE = {
@@ -34,6 +36,8 @@ DICT_RESPONSE = {
     "total": 1,
     "page": 1,
     "pages": 1,
+    "_client": None,
+    "next": None,
 }
 
 

--- a/tests/market_data/test_instruments.py
+++ b/tests/market_data/test_instruments.py
@@ -61,6 +61,8 @@ DUMMY_RESPONSE = GetInstrumentsResponse(
     total=26283,
     page=2,
     pages=263,
+    next="https://data.lemon.markets/v1/instruments/?limit=100&page=3",
+    _client=None
 )
 
 
@@ -86,30 +88,32 @@ class TestInstrumentsApi(CommonMarketDataApiTests):
             ({"limit": 100}, "limit=100"),
             ({"page": 7}, "page=7"),
             (
-                {
-                    "isin": ["XMUN"],
-                    "search": "foo",
-                    "type": ["stock", "etf"],
-                    "mic": ["XMUN"],
-                    "currency": ["USD"],
-                    "tradable": False,
-                    "sorting": "asc",
-                    "limit": 100,
-                    "page": 7,
-                },
-                "isin=XMUN&search=foo&type=stock&type=etf&mic=XMUN&"
-                "currency=USD&tradable=False&sorting=asc&limit=100&page=7",
+                    {
+                        "isin": ["XMUN"],
+                        "search": "foo",
+                        "type": ["stock", "etf"],
+                        "mic": ["XMUN"],
+                        "currency": ["USD"],
+                        "tradable": False,
+                        "sorting": "asc",
+                        "limit": 100,
+                        "page": 7,
+                    },
+                    "isin=XMUN&search=foo&type=stock&type=etf&mic=XMUN&"
+                    "currency=USD&tradable=False&sorting=asc&limit=100&page=7",
             ),
         ],
     )
     def test_get_instruments(
-        self, client: Api, httpserver: HTTPServer, function_kwargs, query_string
+            self, client: Api, httpserver: HTTPServer, function_kwargs, query_string
     ):
         httpserver.expect_oneshot_request(
             "/instruments",
             query_string=query_string,
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
+
+        DUMMY_RESPONSE._client = client.market_data  # Note: dynamically bound a client
         assert client.market_data.instruments.get(**function_kwargs) == DUMMY_RESPONSE
 
     def test_retry_on_error(self, client: Api, httpserver: HTTPServer):
@@ -123,4 +127,5 @@ class TestInstrumentsApi(CommonMarketDataApiTests):
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
 
+        DUMMY_RESPONSE._client = client.market_data  # Note: dynamically bound a client
         assert client.market_data.instruments.get() == DUMMY_RESPONSE

--- a/tests/market_data/test_instruments.py
+++ b/tests/market_data/test_instruments.py
@@ -62,7 +62,7 @@ DUMMY_RESPONSE = GetInstrumentsResponse(
     page=2,
     pages=263,
     next="https://data.lemon.markets/v1/instruments/?limit=100&page=3",
-    _client=None
+    _client=None,
 )
 
 
@@ -88,24 +88,24 @@ class TestInstrumentsApi(CommonMarketDataApiTests):
             ({"limit": 100}, "limit=100"),
             ({"page": 7}, "page=7"),
             (
-                    {
-                        "isin": ["XMUN"],
-                        "search": "foo",
-                        "type": ["stock", "etf"],
-                        "mic": ["XMUN"],
-                        "currency": ["USD"],
-                        "tradable": False,
-                        "sorting": "asc",
-                        "limit": 100,
-                        "page": 7,
-                    },
-                    "isin=XMUN&search=foo&type=stock&type=etf&mic=XMUN&"
-                    "currency=USD&tradable=False&sorting=asc&limit=100&page=7",
+                {
+                    "isin": ["XMUN"],
+                    "search": "foo",
+                    "type": ["stock", "etf"],
+                    "mic": ["XMUN"],
+                    "currency": ["USD"],
+                    "tradable": False,
+                    "sorting": "asc",
+                    "limit": 100,
+                    "page": 7,
+                },
+                "isin=XMUN&search=foo&type=stock&type=etf&mic=XMUN&"
+                "currency=USD&tradable=False&sorting=asc&limit=100&page=7",
             ),
         ],
     )
     def test_get_instruments(
-            self, client: Api, httpserver: HTTPServer, function_kwargs, query_string
+        self, client: Api, httpserver: HTTPServer, function_kwargs, query_string
     ):
         httpserver.expect_oneshot_request(
             "/instruments",

--- a/tests/market_data/test_ohlc.py
+++ b/tests/market_data/test_ohlc.py
@@ -69,6 +69,8 @@ DUMMY_RESPONSE = GetOhlcResponse(
     total=1,
     page=1,
     pages=1,
+    next=None,
+    _client=None,
 )
 
 
@@ -130,6 +132,7 @@ class TestGetOhlcApi(CommonMarketDataApiTests):
             query_string=query_string,
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
+        DUMMY_RESPONSE._client = client.market_data
         assert (
             client.market_data.ohlc.get(period=period, **function_kwargs)
             == DUMMY_RESPONSE
@@ -203,6 +206,8 @@ class TestGetOhlcApi(CommonMarketDataApiTests):
             query_string="isin=XMUN",
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
+
+        DUMMY_RESPONSE._client = client.market_data
 
         assert client.market_data.ohlc.get(period="h1", isin=["XMUN"]) == DUMMY_RESPONSE
 

--- a/tests/market_data/test_ohlc.py
+++ b/tests/market_data/test_ohlc.py
@@ -214,3 +214,15 @@ class TestGetOhlcApi(CommonMarketDataApiTests):
     def test_raise_on_invalid_input(self, client: Api):
         with pytest.raises(ValueError):
             client.market_data.ohlc.get(period="", isin=["XMUN"])  # type: ignore
+
+    def test_iterator(self, client: Api, httpserver):
+        httpserver.expect_oneshot_request(
+            "/ohlc/m1",
+            query_string="isin=XMUN",
+            method="GET",
+        ).respond_with_json(DUMMY_PAYLOAD)
+
+        results = list(
+            client.market_data.ohlc.get(period="m1", isin=["XMUN"]).auto_iter()
+        )
+        assert len(results) == 1

--- a/tests/market_data/test_ohlc.py
+++ b/tests/market_data/test_ohlc.py
@@ -222,7 +222,6 @@ class TestGetOhlcApi(CommonMarketDataApiTests):
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
 
-        results = list(
-            client.market_data.ohlc.get(period="m1", isin=["XMUN"]).auto_iter()
-        )
-        assert len(results) == 1
+        results = client.market_data.ohlc.get(period="m1", isin=["XMUN"]).auto_iter()
+
+        assert list(results) == DUMMY_RESPONSE.results

--- a/tests/market_data/test_quotes.py
+++ b/tests/market_data/test_quotes.py
@@ -64,7 +64,7 @@ DUMMY_RESPONSE = GetQuotesResponse(
     page=1,
     pages=1,
     _client=None,
-    next=None
+    next=None,
 )
 
 

--- a/tests/market_data/test_quotes.py
+++ b/tests/market_data/test_quotes.py
@@ -63,6 +63,8 @@ DUMMY_RESPONSE = GetQuotesResponse(
     total=1,
     page=1,
     pages=1,
+    _client=None,
+    next=None
 )
 
 
@@ -107,6 +109,7 @@ class TestQuotesApi(CommonMarketDataApiTests):
             query_string=query_string,
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
+        DUMMY_RESPONSE._client = client.market_data
         assert client.market_data.quotes.get_latest(**function_kwargs) == DUMMY_RESPONSE
 
     def test_get_quotes_decimal_form(self, client: Api, httpserver: HTTPServer):
@@ -176,4 +179,5 @@ class TestQuotesApi(CommonMarketDataApiTests):
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
 
+        DUMMY_RESPONSE._client = client.market_data
         assert client.market_data.quotes.get_latest(isin=["XMUN"]) == DUMMY_RESPONSE

--- a/tests/market_data/test_trades.py
+++ b/tests/market_data/test_trades.py
@@ -60,6 +60,8 @@ DUMMY_RESPONSE = GetTradesResponse(
     total=1,
     page=1,
     pages=1,
+    next=None,
+    _client=None,
 )
 
 
@@ -104,6 +106,9 @@ class TestTradesApi(CommonMarketDataApiTests):
             query_string=query_string,
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
+
+        DUMMY_RESPONSE._client = client.market_data
+
         assert client.market_data.trades.get_latest(**function_kwargs) == DUMMY_RESPONSE
 
     def test_get_trades_decimal_form(self, client: Api, httpserver: HTTPServer):
@@ -172,5 +177,7 @@ class TestTradesApi(CommonMarketDataApiTests):
             query_string="isin=XMUN",
             method="GET",
         ).respond_with_json(DUMMY_PAYLOAD)
+
+        DUMMY_RESPONSE._client = client.market_data
 
         assert client.market_data.trades.get_latest(isin=["XMUN"]) == DUMMY_RESPONSE

--- a/tests/trading/model/test_account.py
+++ b/tests/trading/model/test_account.py
@@ -107,6 +107,8 @@ GET_WITHDRAWLS_RESPONSE = GetWithdrawalsResponse(
     total=80,
     page=2,
     pages=4,
+    _client=None,
+    next=None,
 )
 
 DICT_GET_WITHDRAWLS_RESPONSE = {
@@ -124,6 +126,8 @@ DICT_GET_WITHDRAWLS_RESPONSE = {
     "total": 80,
     "page": 2,
     "pages": 4,
+    "_client": None,
+    "next": None,
 }
 
 GET_WITHDRAW_RESPONSE = WithdrawResponse(
@@ -156,7 +160,7 @@ GET_BANK_STATEMENTS_RESPONSE = GetBankStatementsResponse(
     page=2,
     pages=4,
     _client=None,
-    next=None
+    next=None,
 )
 
 DICT_GET_BANK_STATEMENTS_RESPONSE = {
@@ -179,7 +183,7 @@ DICT_GET_BANK_STATEMENTS_RESPONSE = {
     "page": 2,
     "pages": 4,
     "_client": None,
-    "next": None
+    "next": None,
 }
 
 GET_DOCUMENTS_RESPONSE = GetDocumentsResponse(
@@ -199,6 +203,8 @@ GET_DOCUMENTS_RESPONSE = GetDocumentsResponse(
     total=80,
     page=2,
     pages=4,
+    _client=None,
+    next=None,
 )
 
 DICT_GET_DOCUMENTS_RESPONSE = {
@@ -218,6 +224,8 @@ DICT_GET_DOCUMENTS_RESPONSE = {
     "total": 80,
     "page": 2,
     "pages": 4,
+    "_client": None,
+    "next": None,
 }
 
 GET_DOCUMENT_RESPONSE = GetDocumentResponse(

--- a/tests/trading/model/test_account.py
+++ b/tests/trading/model/test_account.py
@@ -155,6 +155,8 @@ GET_BANK_STATEMENTS_RESPONSE = GetBankStatementsResponse(
     total=80,
     page=2,
     pages=4,
+    _client=None,
+    next=None
 )
 
 DICT_GET_BANK_STATEMENTS_RESPONSE = {
@@ -176,6 +178,8 @@ DICT_GET_BANK_STATEMENTS_RESPONSE = {
     "total": 80,
     "page": 2,
     "pages": 4,
+    "_client": None,
+    "next": None
 }
 
 GET_DOCUMENTS_RESPONSE = GetDocumentsResponse(

--- a/tests/trading/model/test_orders.py
+++ b/tests/trading/model/test_orders.py
@@ -69,6 +69,8 @@ GET_ORDERS_RESPONSE = GetOrdersResponse(
     total=33,
     page=2,
     pages=4,
+    _client=None,
+    next=None,
 )
 
 DICT_GET_ORDERS_RESPONSE = {
@@ -129,6 +131,8 @@ DICT_GET_ORDERS_RESPONSE = {
     "total": 33,
     "page": 2,
     "pages": 4,
+    "_client": None,
+    "next": None,
 }
 
 CREATE_ORDER_RESPONSE = CreateOrderResponse(

--- a/tests/trading/model/test_position.py
+++ b/tests/trading/model/test_position.py
@@ -25,6 +25,8 @@ GET_POSITIONS_RESPONSE = GetPositionsResponse(
     total=33,
     page=2,
     pages=4,
+    _client=None,
+    next=None,
 )
 
 DICT_GET_POSITIONS_RESPONSE = {
@@ -43,6 +45,8 @@ DICT_GET_POSITIONS_RESPONSE = {
     "total": 33,
     "page": 2,
     "pages": 4,
+    "_client": None,
+    "next": None,
 }
 
 GET_STATEMENTS_RESPONSE = GetStatementsResponse(
@@ -64,6 +68,8 @@ GET_STATEMENTS_RESPONSE = GetStatementsResponse(
     total=33,
     page=2,
     pages=4,
+    _client=None,
+    next=None,
 )
 
 DICT_GET_STATEMENTS_RESPONSE = {
@@ -85,6 +91,8 @@ DICT_GET_STATEMENTS_RESPONSE = {
     "total": 33,
     "page": 2,
     "pages": 4,
+    "_client": None,
+    "next": None,
 }
 
 GET_PERFORMANCE_RESPONSE = GetPerformanceResponse(
@@ -107,6 +115,8 @@ GET_PERFORMANCE_RESPONSE = GetPerformanceResponse(
     total=37,
     page=2,
     pages=4,
+    _client=None,
+    next=None,
 )
 
 DICT_GET_PERFORMANCE_RESPONSE = {
@@ -129,6 +139,8 @@ DICT_GET_PERFORMANCE_RESPONSE = {
     "total": 37,
     "page": 2,
     "pages": 4,
+    "_client": None,
+    "next": None,
 }
 
 

--- a/tests/trading/test_account.py
+++ b/tests/trading/test_account.py
@@ -103,7 +103,7 @@ DUMMY_BANK_STATEMENTS_PAYLOAD = {
         },
     ],
     "previous": "https://paper-trading.lemon.markets/v1/account/bankstatements/?limit=20&page=1",
-    "next": "https://paper-trading.lemon.markets/v1/account/bankstatements/?limit=2&page=3",
+    "next": None,
     "total": 80,
     "page": 2,
     "pages": 4,
@@ -218,6 +218,8 @@ DUMMY_BANKSTATEMENTS_RESPONSE = GetBankStatementsResponse(
     total=80,
     page=2,
     pages=4,
+    _client=None,
+    next=None
 )
 
 DUMMY_GET_DOCUMENTS_RESPONSE = GetDocumentsResponse(
@@ -393,6 +395,7 @@ class TestGetBankStatementsApi(CommonTradingApiTests):
         httpserver.expect_oneshot_request(
             "/account/bankstatements", query_string=query_string, method="GET"
         ).respond_with_json(DUMMY_BANK_STATEMENTS_PAYLOAD)
+        DUMMY_BANKSTATEMENTS_RESPONSE._client = client.trading
         assert (
             client.trading.account.get_bank_statements(**function_kwargs)
             == DUMMY_BANKSTATEMENTS_RESPONSE
@@ -408,6 +411,8 @@ class TestGetBankStatementsApi(CommonTradingApiTests):
             "/account/bankstatements",
             method="GET",
         ).respond_with_json(DUMMY_BANK_STATEMENTS_PAYLOAD)
+
+        DUMMY_BANKSTATEMENTS_RESPONSE._client = client.trading
 
         assert (
             client.trading.account.get_bank_statements()

--- a/tests/trading/test_account.py
+++ b/tests/trading/test_account.py
@@ -192,6 +192,8 @@ DUMMY_WITHDRAWLS_RESPONSE = GetWithdrawalsResponse(
     total=80,
     page=2,
     pages=4,
+    _client=None,
+    next="https://paper-trading.lemon.markets/v1/account/withdrawals/?limit=2&page=3",
 )
 
 DUMMY_WITHDRAW_RESPONSE = WithdrawResponse(
@@ -219,7 +221,7 @@ DUMMY_BANKSTATEMENTS_RESPONSE = GetBankStatementsResponse(
     page=2,
     pages=4,
     _client=None,
-    next=None
+    next=None,
 )
 
 DUMMY_GET_DOCUMENTS_RESPONSE = GetDocumentsResponse(
@@ -239,6 +241,8 @@ DUMMY_GET_DOCUMENTS_RESPONSE = GetDocumentsResponse(
     total=80,
     page=2,
     pages=4,
+    _client=None,
+    next="https://paper-trading.lemon.markets/v1/account/documents/?limit=2&page=3",
 )
 
 DUMMY_GET_DOCUMENT_RESPONSE = GetDocumentResponse(
@@ -318,6 +322,7 @@ class TestGetWithdrawalsApi(CommonTradingApiTests):
             "/account/withdrawals",
             method="GET",
         ).respond_with_json(DUMMY_WITHDRAWLS_PAYLOAD)
+        DUMMY_WITHDRAWLS_RESPONSE._client = client.trading
         assert client.trading.account.get_withdrawals() == DUMMY_WITHDRAWLS_RESPONSE
 
     def test_retry_on_error(self, client: Api, httpserver: HTTPServer):
@@ -331,6 +336,7 @@ class TestGetWithdrawalsApi(CommonTradingApiTests):
             method="GET",
         ).respond_with_json(DUMMY_WITHDRAWLS_PAYLOAD)
 
+        DUMMY_WITHDRAWLS_RESPONSE._client = client.trading
         assert client.trading.account.get_withdrawals() == DUMMY_WITHDRAWLS_RESPONSE
 
 
@@ -451,6 +457,7 @@ class TestGetDocumentsApi(CommonTradingApiTests):
         httpserver.expect_oneshot_request(
             "/account/documents", query_string=query_string, method="GET"
         ).respond_with_json(DUMMY_GET_DOCUMENTS_PAYLOAD)
+        DUMMY_GET_DOCUMENTS_RESPONSE._client = client.trading
         assert (
             client.trading.account.get_documents(**function_kwargs)
             == DUMMY_GET_DOCUMENTS_RESPONSE
@@ -466,6 +473,8 @@ class TestGetDocumentsApi(CommonTradingApiTests):
             "/account/documents",
             method="GET",
         ).respond_with_json(DUMMY_GET_DOCUMENTS_PAYLOAD)
+
+        DUMMY_GET_DOCUMENTS_RESPONSE._client = client.trading
 
         assert client.trading.account.get_documents() == DUMMY_GET_DOCUMENTS_RESPONSE
 

--- a/tests/trading/test_orders.py
+++ b/tests/trading/test_orders.py
@@ -251,6 +251,8 @@ DUMMY_ORDERS_RESPONSE = GetOrdersResponse(
     total=33,
     page=2,
     pages=4,
+    _client=None,
+    next="https://paper-trading.lemon.markets/v1/orders/?limit=10&page=3",
 )
 
 DUMMY_CREATE_ORDER_RESPONSE = CreateOrderResponse(
@@ -418,6 +420,7 @@ class TestGetOrdersApi(CommonTradingApiTests):
             query_string=query_string,
             method="GET",
         ).respond_with_json(DUMMY_ORDERS_PAYLOAD)
+        DUMMY_ORDERS_RESPONSE._client = client.trading
         assert client.trading.orders.get(**function_kwargs) == DUMMY_ORDERS_RESPONSE
 
     def test_retry_on_error(self, client: Api, httpserver: HTTPServer):
@@ -430,7 +433,7 @@ class TestGetOrdersApi(CommonTradingApiTests):
             "/orders",
             method="GET",
         ).respond_with_json(DUMMY_ORDERS_PAYLOAD)
-
+        DUMMY_ORDERS_RESPONSE._client = client.trading
         assert client.trading.orders.get() == DUMMY_ORDERS_RESPONSE
 
 

--- a/tests/trading/test_positions.py
+++ b/tests/trading/test_positions.py
@@ -84,7 +84,6 @@ DUMMY_PERFORMANCE_PAYLOAD = {
     "pages": 4,
 }
 
-
 DUMMY_POSITIONS_RESPONSE = GetPositionsResponse(
     time=datetime.fromisoformat("2021-11-21T19:34:45.071+00:00"),
     mode="paper",
@@ -101,6 +100,8 @@ DUMMY_POSITIONS_RESPONSE = GetPositionsResponse(
     total=33,
     page=2,
     pages=4,
+    _client=None,
+    next="https://paper-trading.lemon.markets/v1/positions/?limit=10&page=3",
 )
 
 DUMMY_STATEMENTS_RESPONSE = GetStatementsResponse(
@@ -122,6 +123,8 @@ DUMMY_STATEMENTS_RESPONSE = GetStatementsResponse(
     total=33,
     page=2,
     pages=4,
+    _client=None,
+    next="https://paper-trading.lemon.markets/v1/positions/statements?limit=10&page=3",
 )
 
 DUMMY_PERFORMANCE_RESPONSE = GetPerformanceResponse(
@@ -144,6 +147,8 @@ DUMMY_PERFORMANCE_RESPONSE = GetPerformanceResponse(
     total=37,
     page=2,
     pages=4,
+    _client=None,
+    next="https://trading.lemon.markets/v1/positions/performance?limit=10&page=3",
 )
 
 
@@ -180,6 +185,7 @@ class TestGetPositionsApi(CommonTradingApiTests):
             query_string=query_string,
             method="GET",
         ).respond_with_json(DUMMY_POSITIONS_PAYLOAD)
+        DUMMY_POSITIONS_RESPONSE._client = client.trading
         assert (
             client.trading.positions.get(**function_kwargs) == DUMMY_POSITIONS_RESPONSE
         )
@@ -194,7 +200,7 @@ class TestGetPositionsApi(CommonTradingApiTests):
             "/positions",
             method="GET",
         ).respond_with_json(DUMMY_POSITIONS_PAYLOAD)
-
+        DUMMY_POSITIONS_RESPONSE._client = client.trading
         assert client.trading.positions.get() == DUMMY_POSITIONS_RESPONSE
 
 
@@ -246,6 +252,7 @@ class TestGetStatementsApi(CommonTradingApiTests):
             query_string=query_string,
             method="GET",
         ).respond_with_json(DUMMY_STATEMENTS_PAYLOAD)
+        DUMMY_STATEMENTS_RESPONSE._client = client.trading
         assert (
             client.trading.positions.get_statements(**function_kwargs)
             == DUMMY_STATEMENTS_RESPONSE
@@ -261,7 +268,7 @@ class TestGetStatementsApi(CommonTradingApiTests):
             "/positions/statements",
             method="GET",
         ).respond_with_json(DUMMY_STATEMENTS_PAYLOAD)
-
+        DUMMY_STATEMENTS_RESPONSE._client = client.trading
         assert client.trading.positions.get_statements() == DUMMY_STATEMENTS_RESPONSE
 
 
@@ -311,6 +318,7 @@ class TestGetPerformanceApi(CommonTradingApiTests):
             query_string=query_string,
             method="GET",
         ).respond_with_json(DUMMY_PERFORMANCE_PAYLOAD)
+        DUMMY_PERFORMANCE_RESPONSE._client = client.trading
         assert (
             client.trading.positions.get_performance(**function_kwargs)
             == DUMMY_PERFORMANCE_RESPONSE
@@ -326,5 +334,5 @@ class TestGetPerformanceApi(CommonTradingApiTests):
             "/positions/performance",
             method="GET",
         ).respond_with_json(DUMMY_PERFORMANCE_PAYLOAD)
-
+        DUMMY_PERFORMANCE_RESPONSE._client = client.trading
         assert client.trading.positions.get_performance() == DUMMY_PERFORMANCE_RESPONSE


### PR DESCRIPTION
Adding iterable responses to list endpoints of the trading API. Bases on #65 