### PR TITLE
fix: workflow tests badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lemon.markets Python SDK
 
 [![License](https://img.shields.io/github/license/lemon-markets/sdk-python)](./LICENSE)
-[![Tests](https://img.shields.io/github/workflow/status/lemon-markets/sdk-python/tests/main?label=tests)](https://github.com/lemon-markets/sdk-python/actions)
+[![Tests](https://github.com/lemon-markets/sdk-python/actions/workflows/tests.yml/badge.svg)](https://github.com/lemon-markets/sdk-python/actions/workflows/tests.yml)
 [![Python versions](https://img.shields.io/pypi/pyversions/lemon.svg)](https://pypi.python.org/pypi/lemon/)
 [![PyPI](https://img.shields.io/pypi/v/lemon)](https://pypi.python.org/pypi/lemon/)
 


### PR DESCRIPTION
Fix #75 by leveraging the native GitHub badges.

See: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge

Also note that the link has been changed to open the specific `tests` worklow. Feel free to edit this according to your needs.